### PR TITLE
Use standard LICENSE text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,3 @@
-OpenStaticAnalyzer 1.0
-
-Copyright (c) 2004-2017 Department of Software Engineering, University of Szeged, Hungary.
-
-Licensed under Version 1.2 of the EUPL (the "Licence");
-
-You may not use this work except in compliance with the Licence.
-
-You may obtain a copy of the Licence in the ANNEX or at:
-
-https://joinup.ec.europa.eu/software/page/eupl
-
-Unless required by applicable law or agreed to in writing, software distributed under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the Licence for the specific language governing permissions and limitations under the Licence.
-
-
-ANNEX
-
 EUROPEAN UNION PUBLIC LICENCE v. 1.2
 EUPL © the European Union 2007, 2016
 


### PR DESCRIPTION
Hi there!

I just wanted to let you know that you could not be featured as users of the EUPL 1.2 license in choosealicense.com because you added a prefix to the license text.
While not having a major impact, I thought you could be interested in having your license automatically detected by GitHub, as could be the case once https://github.com/github/choosealicense.com/pull/523 is merged if you use the standard license text 🙂 

Cheers, and thanks for using the EUPL!